### PR TITLE
fix: removes 'style' from the componentStore keys

### DIFF
--- a/e2eTests/example/ios.fructose.js
+++ b/e2eTests/example/ios.fructose.js
@@ -1,53 +1,72 @@
 /* globals withComponent test expect element by */
 
 import React from "react";
-import { Text } from "react-native";
+import { StyleSheet, Text } from "react-native";
 
-withComponent(<Text>The Philosopher&apos;s Stone</Text>, "basic text", (fructose) => {
-  test("simple test", async () => {
-    await fructose.loadComponent();
-    await expect(element(by.text(`The Philosopher's Stone`))).toBeVisible();
-  });
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 50,
+    fontWeight: "bold"
+  }
 });
 
-withComponent(<Text>The Chamber of Secrets</Text>, "basic text", (fructose) => {
-  test("simple test", async () => {
-    await fructose.loadComponent();
-    await expect(element(by.text("The Chamber of Secrets"))).toBeVisible();
-  });
-});
+withComponent(
+  <Text>The Philosopher&apos;s Stone</Text>,
+  "basic text",
+  fructose => {
+    test("simple test", async () => {
+      await fructose.loadComponent();
+      await expect(element(by.text(`The Philosopher's Stone`))).toBeVisible();
+    });
+  }
+);
 
-withComponent(<Text>The Prisoner of Azkaban</Text>, "basic text", (fructose) => {
+withComponent(
+  <Text style={styles.title}>The Chamber of Secrets</Text>,
+  "basic text",
+  fructose => {
+    test("with style", async () => {
+      await fructose.loadComponent();
+      await expect(element(by.text("The Chamber of Secrets"))).toBeVisible();
+    });
+  }
+);
+
+withComponent(<Text>The Prisoner of Azkaban</Text>, "basic text", fructose => {
   test("simple test", async () => {
     await fructose.loadComponent();
     await expect(element(by.text("The Prisoner of Azkaban"))).toBeVisible();
   });
 });
 
-withComponent(<Text>The Goblet of Fire</Text>, "basic text", (fructose) => {
+withComponent(<Text>The Goblet of Fire</Text>, "basic text", fructose => {
   test("simple test", async () => {
     await fructose.loadComponent();
     await expect(element(by.text("The Goblet of Fire"))).toBeVisible();
   });
 });
 
-withComponent(<Text>The Order of the Phoenix</Text>, "basic text", (fructose) => {
+withComponent(<Text>The Order of the Phoenix</Text>, "basic text", fructose => {
   test("simple test", async () => {
     await fructose.loadComponent();
     await expect(element(by.text("The Order of the Phoenix"))).toBeVisible();
   });
 });
 
-withComponent(<Text>The Half Blood Prince</Text>, "basic text", (fructose) => {
+withComponent(<Text>The Half Blood Prince</Text>, "basic text", fructose => {
   test("simple test", async () => {
     await fructose.loadComponent();
     await expect(element(by.text("The Half Blood Prince"))).toBeVisible();
   });
 });
 
-withComponent(<Text>The Deathly Hallows</Text>, "basic text", (fructose) => {
-  test("simple test", async () => {
-    await fructose.loadComponent();
-    await expect(element(by.text("The Deathly Hallows"))).toBeVisible();
-  });
-});
+withComponent(
+  <Text style={styles.title}>The Deathly Hallows</Text>,
+  "basic text",
+  fructose => {
+    test("simple test", async () => {
+      await fructose.loadComponent();
+      await expect(element(by.text("The Deathly Hallows"))).toBeVisible();
+    });
+  }
+);

--- a/e2eTests/package.json
+++ b/e2eTests/package.json
@@ -14,10 +14,10 @@
 		"write-android-components": "npm run compile-android-components  && compile-tests"
 	},
 	"dependencies": {
+		"detox": "5.5.1",
 		"react": "16.0.0-alpha.6",
 		"react-native": "0.44.1",
 		"react-native-storybook-loader": "^1.4.1",
-		"detox": "5.5.1",
 		"webdriverio": "^4.8.0"
 	},
 	"jest": {

--- a/packages/app/src/componentLoader.js
+++ b/packages/app/src/componentLoader.js
@@ -1,11 +1,13 @@
+import rnComponentKey from "../../common/rnComponentKey";
+
 export default loadComponents => {
   const componentsStore = {};
 
   // create withComponent global that will run when withComponent is encountered
   // in a test file
-  
+
   global.withComponent = component => {
-    const key = JSON.stringify(component).replace(/"\$\$typeof":.*?,/g, "");
+    const key = rnComponentKey(component);
     componentsStore[key] = component;
   };
 

--- a/packages/common/rnComponentKey.js
+++ b/packages/common/rnComponentKey.js
@@ -1,0 +1,7 @@
+module.exports = component => {
+  const stringified = JSON.stringify(component);
+  const removeTypeof = s => s.replace(/"\$\$typeof":.*?,/g, "");
+  const removeStyleCode = s => s.replace(/"style":.*?,/g, "");
+  const removeStyleObject = s => s.replace(/"style":{.*?},/g, "");
+  return removeTypeof(removeStyleCode(removeStyleObject(stringified)));
+};

--- a/packages/test-helpers/src/withComponent.js
+++ b/packages/test-helpers/src/withComponent.js
@@ -1,12 +1,13 @@
 /* globals describe */
 import log from "npmlog";
 import Client from "../../client";
+import rnComponentKey from "../../common/rnComponentKey";
 
 const client = Client(7811);
 log.verbose("client socket", client.socket);
 export default () => {
   const withComponent = (component, description, tests) => {
-    const hashed = JSON.stringify(component);
+    const hashed = rnComponentKey(component);
 
     const loadComponent = async () =>
       client


### PR DESCRIPTION
Styles in the native process vs. the test process get set differently. On the device a style has a numerical value, whereas in the test process it is an object. removing styles from the key so we have consistency across the tester and the app.