### PR TITLE
feature: give users ability to specify fructose dir

### DIFF
--- a/e2eTests/package.json
+++ b/e2eTests/package.json
@@ -15,9 +15,9 @@
         "compile-android-components": "rnstl --searchDir ./ --pattern 'example/android.fructose.js' --outputFile ./.fructose/components.js",
         "compile-ios-components": "rnstl --searchDir ./ --pattern 'example/ios.fructose.js' --outputFile ./.fructose/components.js",
         "compile-web-components": "rnstl --searchDir ./ --pattern 'example/web.fructose.js' --outputFile ./.fructose/components.js",
-        "write-web-components": "npm run compile-web-components  && compile-tests",
-        "write-ios-components": "npm run compile-ios-components  && compile-tests",
-        "write-android-components": "npm run compile-android-components  && compile-tests"
+        "write-web-components": "npm run compile-web-components  &&  compile-tests -d .fructose -t components.test.js -a components.js",
+        "write-ios-components": "npm run compile-ios-components  &&  npx compile-tests -d .fructose -t components.test.js -a components.js",
+        "write-android-components": "npm run compile-android-components  && npx compile-tests -d .fructose -t components.test.js -a components.js"
     },
     "dependencies": {
         "@times-components/image": "^1.2.0",

--- a/packages/test-helpers/bin/writeComponentsTests.js
+++ b/packages/test-helpers/bin/writeComponentsTests.js
@@ -1,6 +1,44 @@
 #!/usr/bin/env node
-
+const program = require("commander");
 const fs = require("fs");
+
+const version = require("../../../package").version;
+
+program
+  .version(version)
+  .option(
+    "-d, --directory <directory>",
+    "Specify fructose root, default is [.fructose]"
+  )
+  .option(
+    "-t, --test-entry-filename <testEntryFile>",
+    "Specify the test entry file name, default is [components.test.js]"
+  )
+  .option(
+    "-a, --app-entry-filename <appEntryFile>",
+    "Specify the app entry file name, default is [components.js]"
+  )
+  .parse(process.argv);
+
+const directory = program.directory ? program.directory : ".fructose";
+const testEntryFilename = program.testEntryFilename
+  ? program.testEntryFilename
+  : "components.test.js";
+const appEntryFilename = program.appEntryFilename
+  ? program.appEntryFilename
+  : "components.js";
+
+if (!directory) {
+  throw new Error("fructose root not specified, specify with -d");
+}
+
+if (!testEntryFilename) {
+  throw new Error("test entry file not specified, specify with -t");
+}
+
+if (!appEntryFilename) {
+  throw new Error("app entry file is not specified, specify with -a");
+}
 
 const writeFile = (data, path) =>
   new Promise((resolve, reject) => {
@@ -8,21 +46,22 @@ const writeFile = (data, path) =>
       if (err) {
         reject(err);
       }
-      resolve("wrote tests to file");
+      console.log("wrote tests to file");
+      resolve();
     });
   });
 
 const readTestComponents = () =>
   new Promise(resolve => {
     fs.readFile(
-      ".fructose/components.js",
+      `${directory}/${appEntryFilename}`,
       { encoding: "utf8" },
       (err, data) => {
         const tests = data
           .split("\n")
           .filter(line => line.trim().startsWith("require"))
           .join("\n");
-        writeFile(tests, ".fructose/components.test.js").then(resolve);
+        writeFile(tests, `${directory}/${testEntryFilename}`).then(resolve);
       }
     );
   });


### PR DESCRIPTION
for `compile-tests` command you can now specify fructose directory, app Entry file, and test entry file